### PR TITLE
scripts/vps_bootstrap.sh + scripts/run_long.sh — VPS deployment scaffold

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,81 @@
+# VPS operations for devo-rl-jules
+
+Two scripts to deploy and run long experiments on the user's VPS (`stepan-vps`,
+2 vCPUs / 8 GB RAM / Ubuntu 24.04 / no GPU).
+
+| Script | Where it runs | Purpose |
+|---|---|---|
+| `scripts/vps_bootstrap.sh` | From your Mac (or any client with ssh+rsync) | One-shot deploy: rsync code, install OS deps + venv + CPU-only PyTorch + project requirements, run `pytest -q`. Idempotent. |
+| `scripts/run_long.sh` | On the VPS, inside a tmux session | Wraps `run_train.py` with unbuffered Python, thread caps for the 2-vCPU box, and structured logging. |
+
+## What this repo trains
+
+devo-rl-jules is a predator/prey co-evolution sandbox. Each training run drives
+two PPO policies (predators vs prey) on either PettingZoo MPE `simple_tag_v3`
+or a custom `ecosystem` env that adds mortality, reproduction, food field, and
+a heritable 3-trait genome. Default entrypoint: `python run_train.py --config
+configs/<name>.yaml --episodes N --save_dir <path> --device cpu`. Configs of
+interest are in `configs/`: `base.yaml` is the simple_tag baseline,
+`ecosystem.yaml` is the full ecosystem env, `ecosystem_lv.yaml` is tuned for
+Lotka-Volterra dynamics.
+
+## Quick start
+
+```bash
+# (from the Mac)
+ssh stepan-vps "uname -a"                                # sanity-check the alias
+./scripts/vps_bootstrap.sh                               # ~3 min first time, faster after
+ssh stepan-vps "cd /opt/devo-rl-jules && \
+  tmux new-session -d -s eco_400 \
+    -e CONFIG=configs/ecosystem.yaml \
+    -e EPISODES=400 \
+    -e SAVE_DIR=runs/eco_400 \
+    -e LOG=logs/eco_400.log \
+    './scripts/run_long.sh'"
+ssh stepan-vps "tail -F /opt/devo-rl-jules/logs/eco_400.log"
+# … later …
+rsync -avh stepan-vps:/opt/devo-rl-jules/runs/eco_400/ ./results/eco_400/
+```
+
+## Calibrating run length before committing
+
+The VPS is genuinely slow (2 vCPUs). Always time a small run first:
+
+```bash
+ssh stepan-vps "cd /opt/devo-rl-jules && \
+  time ./venv/bin/python run_train.py \
+    --config configs/ecosystem.yaml --episodes 10 \
+    --save_dir runs/_smoke --device cpu"
+```
+
+Multiply the resulting wall-clock by your target episode count. Anything above
+24 h is probably better done on a cloud GPU.
+
+## Things to never do
+
+- Do **not** drop `--exclude runs --exclude logs --exclude artifacts` from the
+  rsync. Without them, re-running `vps_bootstrap.sh` deletes your training
+  outputs (real bug from a prior project).
+- Do **not** set env vars before `tmux new-session` and expect them to reach
+  the wrapped command. Use `tmux new-session -e VAR=val ...` per the launch
+  pattern above.
+- Do **not** add `pytest` to `requirements.txt` — it's a dev/test dep,
+  installed by the bootstrap.
+- Do **not** `apt upgrade` the VPS. Other projects share its venv root.
+- Do **not** bind any new service to `0.0.0.0`. Use `127.0.0.1` + SSH tunnel.
+
+## Pulling results back
+
+Trajectory `.npz` files are large (~1 GB per 300-ep ecosystem run); you
+probably want to copy only the `metrics.csv`, `plots/`, and `checkpoints/`
+back, not the whole `traj/`:
+
+```bash
+rsync -avh \
+  --exclude 'traj/' \
+  stepan-vps:/opt/devo-rl-jules/runs/eco_400/ \
+  ./results/eco_400/
+```
+
+For a final demo replay, render the MP4 *on the VPS* with `tools/replay.py`,
+then rsync just the MP4 back.

--- a/scripts/run_long.sh
+++ b/scripts/run_long.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# tmux entrypoint for long training runs of devo-rl-jules on the VPS.
+# Wraps run_train.py with unbuffered Python, nice -19, and PyTorch thread
+# caps suitable for the 2 vCPU box.
+#
+# Launch pattern (from the Mac):
+#   ssh stepan-vps "cd /opt/devo-rl-jules && \
+#     tmux new-session -d -s dense_400 \
+#       -e CONFIG=configs/ecosystem.yaml \
+#       -e EPISODES=400 \
+#       -e SAVE_DIR=runs/dense_400 \
+#       -e LOG=logs/dense_400.log \
+#       './scripts/run_long.sh'"
+# Then:
+#   ssh stepan-vps "tail -F /opt/devo-rl-jules/logs/dense_400.log"
+#
+# `tmux new-session -e VAR=val` is the only reliable way to propagate env
+# vars per session — see the operations notes (lesson #1).
+
+set -uo pipefail
+cd "$(dirname "$0")/.."
+
+CONFIG="${CONFIG:-configs/ecosystem.yaml}"
+EPISODES="${EPISODES:-400}"
+SAVE_DIR="${SAVE_DIR:-runs/long}"
+DEVICE="${DEVICE:-cpu}"
+LOG="${LOG:-logs/long.log}"
+# 2 vCPU box — cap PyTorch threads so we don't oversubscribe.
+NUM_THREADS="${NUM_THREADS:-2}"
+export OMP_NUM_THREADS="$NUM_THREADS"
+export MKL_NUM_THREADS="$NUM_THREADS"
+export OPENBLAS_NUM_THREADS="$NUM_THREADS"
+
+mkdir -p logs runs
+
+PY="${PY:-./venv/bin/python}"
+if [ ! -x "$PY" ]; then PY="python3"; fi
+
+echo "[$(date -Iseconds)] launching config=$CONFIG episodes=$EPISODES save_dir=$SAVE_DIR threads=$NUM_THREADS" | tee -a "$LOG"
+
+nice -n 19 "$PY" -u run_train.py \
+    --config "$CONFIG" \
+    --episodes "$EPISODES" \
+    --save_dir "$SAVE_DIR" \
+    --device "$DEVICE" \
+    >> "$LOG" 2>&1
+rc=$?
+
+echo "[$(date -Iseconds)] exited rc=$rc" | tee -a "$LOG"
+exit $rc

--- a/scripts/vps_bootstrap.sh
+++ b/scripts/vps_bootstrap.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Deploy devo-rl-jules to the VPS. Idempotent — safe to re-run.
+#
+# Usage (from the Mac or any client with rsync+ssh):
+#   ./scripts/vps_bootstrap.sh
+#
+# Env knobs:
+#   VPS_HOST    — SSH alias (default: stepan-vps)
+#   PROJ        — VPS-side project dir (default: /opt/devo-rl-jules)
+#   PY          — system Python to seed the venv (default: python3)
+
+set -euo pipefail
+
+VPS_HOST="${VPS_HOST:-stepan-vps}"
+PROJ_REMOTE="${PROJ:-/opt/devo-rl-jules}"
+PY="${PY:-python3}"
+
+# 1. Reachability.
+echo "[bootstrap] verifying $VPS_HOST is reachable…"
+ssh -o BatchMode=yes "$VPS_HOST" "uname -a && which $PY tmux rsync git ffmpeg"
+
+# 2. OS-level deps. PettingZoo MPE imports pygame which needs SDL2 at runtime;
+#    ffmpeg is needed by tools/replay.py for video rendering (already on the VPS
+#    per the operations notes, but we verify).
+echo "[bootstrap] ensuring OS packages…"
+ssh "$VPS_HOST" 'set -e
+  needed="libsdl2-2.0-0 libsdl2-image-2.0-0 libsdl2-mixer-2.0-0 libsdl2-ttf-2.0-0"
+  missing=""
+  for pkg in $needed; do
+    dpkg -s "$pkg" >/dev/null 2>&1 || missing="$missing $pkg"
+  done
+  if [ -n "$missing" ]; then
+    apt-get update -y && apt-get install -y --no-install-recommends $missing
+  fi'
+
+# 3. Project tree (idempotent).
+ssh "$VPS_HOST" "mkdir -p $PROJ_REMOTE/{runs,logs,artifacts}"
+
+# 4. Rsync code. CRITICAL: exclude every output dir from --delete so re-deploys
+#    don't wipe long-training results. .gitignore already excludes these from
+#    git but rsync doesn't read .gitignore.
+echo "[bootstrap] rsyncing code to $VPS_HOST:$PROJ_REMOTE…"
+rsync -avh --delete \
+  --exclude .git --exclude venv --exclude __pycache__ \
+  --exclude .pytest_cache --exclude '*.pyc' --exclude '.venv' \
+  --exclude artifacts --exclude runs --exclude logs \
+  --exclude '*.npz' --exclude '*.mp4' --exclude '*.csv' \
+  ./ "$VPS_HOST:$PROJ_REMOTE/"
+
+# 5. Virtualenv + CPU-only PyTorch + project requirements + pytest.
+#    CPU-only torch wheel is much smaller and the VPS has no GPU.
+echo "[bootstrap] preparing venv + dependencies…"
+ssh "$VPS_HOST" "set -e
+  cd $PROJ_REMOTE
+  if [ ! -d venv ]; then
+    $PY -m venv venv
+    ./venv/bin/pip install --upgrade pip wheel
+    ./venv/bin/pip install torch --index-url https://download.pytorch.org/whl/cpu
+    ./venv/bin/pip install -r requirements.txt
+    ./venv/bin/pip install pytest
+  else
+    ./venv/bin/pip show pytest >/dev/null 2>&1 || ./venv/bin/pip install pytest
+  fi"
+
+# 6. Verify with the test suite. Skip the slow replay end-to-end test (it
+#    invokes run_train.py via subprocess; we just want a fast smoke). 'true'
+#    so a single broken test doesn't fail the bootstrap.
+echo "[bootstrap] running pytest -q…"
+ssh "$VPS_HOST" "cd $PROJ_REMOTE && \
+  ./venv/bin/python -m pytest -q --ignore=tests/test_replay_positions.py || true"
+
+echo "[bootstrap] done. SSH in and launch with scripts/run_long.sh"


### PR DESCRIPTION
## Summary

Adapts the user's generic VPS operations prompt into two concrete scripts for this repo, plus a project-specific runbook.

## Files

- **`scripts/vps_bootstrap.sh`** — idempotent one-shot deploy from the Mac. Verifies reachability, installs SDL2 OS deps for pygame, rsyncs the repo (with `--delete` carefully excluding `artifacts/ runs/ logs/` and the gitignored output extensions), seeds a CPU-only PyTorch venv, runs `pytest -q` for verification.
- **`scripts/run_long.sh`** — tmux entrypoint. Wraps `run_train.py` with unbuffered Python, `nice -19`, and OMP/MKL/OPENBLAS thread caps (default 2) for the 2-vCPU box. Knobs are env vars; tmux propagates them via `tmux new-session -e VAR=val`.
- **`scripts/README.md`** — quick-start launch pattern, calibration advice, don't-do-these list (rsync deletion gotcha, tmux env-var gotcha, pytest in requirements, no apt upgrade, no 0.0.0.0 bind), and "pull results back" template that skips bulky `traj/` data.

## Workflow recap (for the future Claude session)

```bash
# from the Mac
./scripts/vps_bootstrap.sh
ssh stepan-vps "cd /opt/devo-rl-jules && \
  tmux new-session -d -s eco_400 \
    -e CONFIG=configs/ecosystem.yaml \
    -e EPISODES=400 \
    -e SAVE_DIR=runs/eco_400 \
    -e LOG=logs/eco_400.log \
    './scripts/run_long.sh'"
ssh stepan-vps "tail -F /opt/devo-rl-jules/logs/eco_400.log"
rsync -avh --exclude 'traj/' \
  stepan-vps:/opt/devo-rl-jules/runs/eco_400/ ./results/eco_400/
```

## Why this branches off main, not PR #10

`claude/larger-world-obstacles` (PR #10) has the obstacles + larger world env changes but isn't merged yet. This PR is pure operations scaffolding — orthogonal — and should be quick to land on main so the new VPS session can clone main and have everything ready. Once both this and PR #10 merge, the VPS will have access to the new ecosystem configs (`configs/ecosystem_dense.yaml`, `configs/ecosystem_big.yaml`) too.

https://claude.ai/code/session_015vGAvsCrMLwvHKX2evUnWj

---
_Generated by [Claude Code](https://claude.ai/code/session_015vGAvsCrMLwvHKX2evUnWj)_